### PR TITLE
Fix FutureWarning in numpy 1.15

### DIFF
--- a/pyfiberamp/util/sliced_array.py
+++ b/pyfiberamp/util/sliced_array.py
@@ -20,7 +20,7 @@ class SlicedArray(np.ndarray):
 
     def __getattr__(self, item):
         if self.item_in_slice_names(item):
-            return np.array(super().__getitem__([self.slices[item]]))
+            return np.array(super().__getitem__(self.slices[item]))
         else:
             raise AttributeError('SlicedArray does not have attribute {}.'.format(item))
 


### PR DESCRIPTION
Non-tuple sequence for multidimensional indexing is deprecated. 